### PR TITLE
Add missing installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Tree-sitter grammar for [svelte](https://svelte.dev)
 npm i tree-sitter-svelte tree-sitter
 ```
 
+Tree-sitter also requires [nodemon](https://nodemon.io/) to run, so also install that if you don’t already have it:
+
+```
+npm i -g nodemon
+```
+
 # Dev
 
 After installation (`npm i`),

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Tree-sitter also requires [nodemon](https://nodemon.io/) to run, so also install
 npm i -g nodemon
 ```
 
+Finally, you will need [pnpm](https://pnpm.io/installation). If you’re running Node 16.13 or later, it comes as part of Node so you can simply run the following to activate it:
+
+```
+corepack enable
+```
+
 # Dev
 
 After installation (`npm i`),


### PR DESCRIPTION
Installation requires nodemon and pnpm, which are not currently mentioned in the installation section. Without these, `npm run dev` will fail. This patch adds instructions on how to install them to the installation section.