### PR TITLE
Take the absolute value of tag type before casting

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -76,7 +76,7 @@ void deserialize(Scanner *scanner, const char *buffer, unsigned length) {
     vc_vector_resize(scanner->tags, tag_count, initTag(scanner->A));
     for (unsigned j = 0; j < serialized_tag_count; j++) {
       Tag *tag = vc_vector_at(scanner->tags, j);
-      tag->type = (TagType)(buffer[i++]);
+      tag->type = (TagType)(abs(buffer[i++]));
       if (tag->type == CUSTOM) {
         uint16_t name_length = (uint8_t)(buffer[i++]);
         tag->custom_tag_name =


### PR DESCRIPTION
In [my fork](https://github.com/small-tech/tree-sitter-nodekit/tree/nodekit) I added a `GET` element/tag (which includes JavaScript code that’s executed on the server) and this caused some of the other tests to fail.

Looking into the issue, I was able to narrow it down to the `compareTags()` call in the `scan_end_tag_name` in src/scanner.c failing and resulting in `ERRORNEOUS_END_TAG_NAME` errors whenever a custom tag was encounter. Looking deeper, I saw that the comparison of `a->type` and `b->type` in `compareTags` was failing with `-128 != 128`. Given `TagType` should be unsigned, I started wondering where a negative value could have crept in and looked for any casts that might be happening, which led me to the one in the `vc_vector_resize()` function in this pull request.

Taking the absolute value of the value in the buffer before casting it seems to have solved the issue and all my tests are passing again.

This doesn’t affect the tree-sitter-svelte codebase as it stands currently but it should arise if you were to add another tag to `TagType` in the future.