### PR TITLE
Support array literals in `#each` blocks

### DIFF
--- a/test/corpus/svelte.txt
+++ b/test/corpus/svelte.txt
@@ -122,6 +122,41 @@ logical_blocks
     (expression (raw_text_expr))
 )
 
+==========================
+each (with unusual values)
+==========================
+{#each "abcd" as letter}
+  {letter}
+{/each}
+
+{#each ["a", "b"] as elem}
+  {elem}
+{/each}
+
+{#each [["a", "b"], ["c", "d"]] as pair}
+  {#each pair as letter}{letter}{/each}
+{/each}
+
+-------
+(document
+  (each_statement
+    (each_start_expr (special_block_keyword) (raw_text_each) (as) (raw_text_expr))
+    (expression (raw_text_expr))
+    (each_end_expr (special_block_keyword)))
+  (each_statement
+    (each_start_expr (special_block_keyword) (raw_text_each) (as) (raw_text_expr))
+    (expression (raw_text_expr))
+    (each_end_expr (special_block_keyword)))
+  (each_statement
+    (each_start_expr (special_block_keyword) (raw_text_each) (as) (raw_text_expr))
+    (each_statement
+      (each_start_expr (special_block_keyword) (raw_text_each) (as) (raw_text_expr))
+      (expression (raw_text_expr))
+      (each_end_expr (special_block_keyword)))
+    (each_end_expr (special_block_keyword))
+  )
+)
+
 =======================
 await
 ========================


### PR DESCRIPTION
Fixes #48.

I failed to find a comprehensive spec for `#each`, but experimentation in the REPL shows that it can take any sort of array literal, any sort of string, or a single identifier. (There may be more valid input, but someone else can explore those edge cases.)

String literals were already valid, so it was just a matter of consuming everything between balanced `[` and `]`. (Just for `#each`, though; array literals are not valid in `#await`.)

Originally I had it so that the calls to `scan_for_balanced_character` would inspect the returned boolean and `return false` themselves if they got a `false` value — i.e., bailing early from a catastrophic parsing failure instead of proceeding to the end of the file. But this broke the test case in `random.txt`, so I reverted that change.