### PR TITLE
Fixed `await ... then` block without a value after`then`

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -255,7 +255,7 @@ bool scan_word(TSLexer *lexer, ekstring word) {
     lexer->advance(lexer, false);
     c = lexer->lookahead;
   }
-  return (c == '{' || iswspace(c));
+  return (c == '{' || iswspace(c) || c == '}');
 }
 
 bool scan_raw_text_expr(Scanner *scanner, TSLexer *lexer,

--- a/test/corpus/svelte.txt
+++ b/test/corpus/svelte.txt
@@ -135,6 +135,11 @@ await
 {/await}
 {#await yo thenvalue}
 {/await}
+{#await loading}
+{:then}
+{/await}
+{#await loading then}
+{/await}
 ------
 (document
     (await_statement
@@ -152,6 +157,17 @@ await
     )
     (await_statement
         (await_start_expr (special_block_keyword) (raw_text_expr))
+        (await_end_expr (special_block_keyword))
+    )
+    (await_statement
+		(await_start_expr (special_block_keyword) (raw_text_expr))
+        (then_statement
+			(then_expr (special_block_keyword) (raw_text_expr))
+			(await_end_expr (special_block_keyword))
+		)
+	)
+    (await_statement
+        (await_start_expr (special_block_keyword) (raw_text_await) (then) (raw_text_expr))
         (await_end_expr (special_block_keyword))
     )
 )


### PR DESCRIPTION
closes #52

Fixed by adding `}` as a termination symbol for `raw_text_expr`s
