### PR TITLE
Enable build by msvc

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,6 +19,13 @@
           "-std=c++14"
         ],
         'CLANG_CXX_LANGUAGE_STANDARD': 'c++14'
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": [
+            '-utf-8'
+          ],
+        },
       }
     }
   ],

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -4,6 +4,7 @@ fn main() {
     let dir: PathBuf = ["src"].iter().collect(); 
     cc::Build::new()
         .include(&dir)
+        .flag_if_supported("-utf-8")
         .file(dir.join("parser.c"))
         .file(dir.join("scanner.c"))
         .compile("tree-sitter-svelte");

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -395,12 +395,17 @@ bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
   return false;
 }
 
+#ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
 void deleter(void *tag, za_Allocator *A) {}
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
 #pragma clang diagnostic pop
+#endif
+
 void *tree_sitter_svelte_external_scanner_create() {
   za_Allocator *A = za_New();
   Scanner *scanner = (Scanner *)za_Alloc(A, sizeof(Scanner));


### PR DESCRIPTION
[`-utf-8`](https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170) option is needed when compile non-ascii unicode source with MSVC.