### PR TITLE
Allow newlines when scanning for balanced braces

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -267,10 +267,6 @@ bool scan_for_balanced_character(TSLexer *lexer, char open, char closed) {
     } else if (c == closed) {
       stack--;
       if (stack == 0) return true;
-    } else if (c == '\n') {
-      // This can only happen if the braces are unbalanced, in which case
-      // there's utter chaos anyway.
-      return false;
     }
     lexer->advance(lexer, false);
     c = lexer->lookahead;

--- a/test/corpus/svelte.txt
+++ b/test/corpus/svelte.txt
@@ -21,6 +21,23 @@ Raw Text Expression
         (end_tag (tag_name)))
 )
 
+================
+Expression with newlines
+================
+<img src={{
+  src: "foo"
+}} alt="A man dances">
+----
+
+(document
+    (element
+        (start_tag (tag_name)
+            (attribute (attribute_name) (expr_attribute_value (expression (raw_text_expr))))
+            (attribute (attribute_name) (quoted_attribute_value (attribute_value)))
+        )
+
+    )
+)
 ==============
 Dynamic Expression Attribute
 ==============
@@ -133,12 +150,28 @@ each (with unusual values)
   {elem}
 {/each}
 
+{#each [{ foo: "bar" }, { baz: "thud" }] as pair}
+  {elem}
+{/each}
+
 {#each [["a", "b"], ["c", "d"]] as pair}
   {#each pair as letter}{letter}{/each}
 {/each}
 
+{#each ["a", y, ...foo] as item}
+	{item}
+{/each}
+
+{#each { foo: [1, 2, 3] }["foo"] as num}
+	{num}
+{/each}
+
 -------
 (document
+  (each_statement
+    (each_start_expr (special_block_keyword) (raw_text_each) (as) (raw_text_expr))
+    (expression (raw_text_expr))
+    (each_end_expr (special_block_keyword)))
   (each_statement
     (each_start_expr (special_block_keyword) (raw_text_each) (as) (raw_text_expr))
     (expression (raw_text_expr))
@@ -155,6 +188,15 @@ each (with unusual values)
       (each_end_expr (special_block_keyword)))
     (each_end_expr (special_block_keyword))
   )
+  (each_statement
+    (each_start_expr (special_block_keyword) (raw_text_each) (as) (raw_text_expr))
+    (expression (raw_text_expr))
+    (each_end_expr (special_block_keyword)))
+  (each_statement
+    (each_start_expr (special_block_keyword) (raw_text_each) (as) (raw_text_expr))
+    (expression (raw_text_expr))
+    (each_end_expr (special_block_keyword)))
+
 )
 
 =======================


### PR DESCRIPTION
I believe this will fix the regression [reported here](https://github.com/Himujjal/tree-sitter-svelte/pull/50#issuecomment-2331123515). I also took the opportunity to test some of the oddballs of `#each` syntax that @AlbertMarashi mentioned. Somehow they all work just fine. I've added them to the corpus, since Svelte seems to treat them all as valid syntax.

@Himujjal has graciously given me the commit bit on this repo and I'll use it eventually, but I'll leave this PR open for a day or two in case someone has the ability to test whether it fixes the issue.